### PR TITLE
Update button template to work with glyphicons

### DIFF
--- a/frontend/blocks/button/button.jade
+++ b/frontend/blocks/button/button.jade
@@ -1,5 +1,12 @@
-button.btn.btn-default(
-    class="#{_prefix}-button #{cls}",
-    type=type || "button",
+button.btn(
+    class=[
+        "#{_prefix}-button",
+        type=type || "button",
+        cls
+    ],
     disabled=disabled
-) #{label}
+)
+    if glyphicon
+        | <span class="glyphicon glyphicon-#{glyphicon}"></span> #{label}
+    else
+        = label

--- a/public/examples/forms/basic.json
+++ b/public/examples/forms/basic.json
@@ -27,6 +27,17 @@
         {
           "block": "button",
           "label": "Cancel"
+        },
+        {
+          "block": "button",
+          "label": "Delete",
+          "glyphicon": "trash",
+          "cls": "btn-danger"
+        },
+        {
+          "block": "button",
+          "glyphicon": "envelope",
+          "cls": "btn-link"
         }
       ]
     }


### PR DESCRIPTION
Introducing new behavior of buttons:
![selection_001](https://cloud.githubusercontent.com/assets/5839225/15647252/4596e498-2684-11e6-8238-0a9653032253.png)

This was created with following configuration:
```JSON
        {
          "block": "button",
          "label": "OK",
          "disabled": true,
          "cls": "btn-primary"
        },
        {
          "block": "button",
          "label": "Cancel"
        },
        {
          "block": "button",
          "label": "Delete",
          "glyphicon": "trash",
          "cls": "btn-danger"
        },
        {
          "block": "button",
          "glyphicon": "envelope",
          "cls": "btn-link"
        }
```
---------------------
Known problem: this won't work well with our `fieldset`:
![selection_002](https://cloud.githubusercontent.com/assets/5839225/15647295/82f09708-2684-11e6-8d30-f6aa2ef9a67b.png)
