### PR TITLE
Fix dropdown of select does not hide other select

### DIFF
--- a/frontend/blocks/select/select.css
+++ b/frontend/blocks/select/select.css
@@ -77,8 +77,6 @@ $jq-select-dropdown-clr: #fff;
   }
 
   .jq-selectbox {
-    z-index: 5 !important;
-
     &.focused .jq-selectbox__select {
       border-color: $jq-select-border-focus-clr;
     }


### PR DESCRIPTION
## Tested combinations
- Under other select
- Part of fieldset
- Part of table
- Above table
- Above array 
- Above and under address